### PR TITLE
match package name

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ EXEEXT = @EXEEXT@
 LOCAL_PATHS = "@LOCAL_PATHS@"
 
 # Module-specific stuff
-PACKAGE   = Gauche-kakasi
+PACKAGE   = Gauche-text-kakasi
 
 ARCHFILES = text--kakasi.$(SOEXT)
 SCMFILES  = $(srcdir)/text/kakasi.scm


### PR DESCRIPTION
There would be `Gauche-text-kakasi.gpd` after successful `./configure`. But the resulted `Makefile` requires `Gauche-kakasi.gpd` instead.